### PR TITLE
add enforcement of admin teams on github repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Allstar is configured to opt-out. Feel free to submit a PR to disable repos.
 
 These are the expected settings to be in compliance
 
+### [Admin Requirements](admin.yaml)
+
+|   |   |
+| - | - |
+| Owner-less repositories allowed | false |
+| Teams allowed to be admins | true |
+| Maximum admin teams | 1 |
+
 ### [Branch Protection](branch_protection.yaml)
 
 | | |

--- a/admin.yml
+++ b/admin.yml
@@ -1,0 +1,9 @@
+# Repo admin/owner check
+optConfig:
+  disableRepoOverride: true
+  optOutStrategy: true
+action: issue
+# Policies
+ownerlessAllowed: false
+teamAdminsAllowed: true
+maxNumberAdminTeams: 1


### PR DESCRIPTION
## Changes proposed in this pull request:

- add configuration to control allowed admins for all cloud-gov repos
- document new configuration

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This change will improve security by ensuring that for all cloud-gov repos there is only one allowed administrator which must be a team and not an individual user
