### PR TITLE
update policies to opt out archived repos

### DIFF
--- a/admin.yaml
+++ b/admin.yaml
@@ -5,6 +5,7 @@
 optConfig:
   disableRepoOverride: true
   optOutStrategy: true
+  optOutArchivedRepos: true
 action: issue
 # Policies
 ownerlessAllowed: false

--- a/binary_artifacts.yaml
+++ b/binary_artifacts.yaml
@@ -4,6 +4,7 @@
 optConfig:
   disableRepoOverride: true
   optOutStrategy: true
+  optOutArchivedRepos: true
 action: issue
 # Policies
 ignoreFiles: []

--- a/dangerous_workflow.yaml
+++ b/dangerous_workflow.yaml
@@ -2,5 +2,6 @@
 optConfig:
   disableRepoOverride: false
   optOutStrategy: true
+  optOutArchivedRepos: true
 action: issue
 # Policies

--- a/outside.yaml
+++ b/outside.yaml
@@ -6,6 +6,7 @@
 optConfig:
   disableRepoOverride: true
   optOutStrategy: true
+  optOutArchivedRepos: true
 action: issue
 # Policies
 adminAllowed: false

--- a/scorecard.yml
+++ b/scorecard.yml
@@ -2,6 +2,7 @@
 optConfig:
   disableRepoOverride: true
   optOutStrategy: true
+  optOutArchivedRepos: true
 action: issue
 # Policies
 # This are documented here: https://github.com/ossf/scorecard/blob/main/docs/checks/internal/checks.yaml

--- a/security.yaml
+++ b/security.yaml
@@ -3,4 +3,5 @@
 optConfig:
   disableRepoOverride: true
   optOutStrategy: true
+  optOutArchivedRepos: true
 action: issue


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update policies to ignore archived repos

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Allstar supports security by encouraging consistent, secure settings across all of our GitHub repositories
