### PR TITLE
allow override of binary artifacts policy per repo

### DIFF
--- a/binary_artifacts.yaml
+++ b/binary_artifacts.yaml
@@ -2,7 +2,7 @@
 # Partial implementation of
 # SI-3: Malicious Code Protection
 optConfig:
-  disableRepoOverride: true
+  disableRepoOverride: false
   optOutStrategy: true
   optOutArchivedRepos: true
 action: issue


### PR DESCRIPTION
## Changes proposed in this pull request:

Binary artifacts in a repo are something that we want to avoid most of the time. Per Allstar:

> Binary Artifacts are an increased security risk in your repository. Binary artifacts cannot be reviewed, allowing the introduction of possibly obsolete or maliciously subverted executables

However, there are cases where a binary artifact may be okay and expected. So this PR updates the core configuration for the Binary Artifacts policy to allow the configuration to be overridden per repo, which allows us to specify lists of binary files per repo that should be ignored by Allstar

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These changes mean that the Binary Artifacts policy will still be enforced by Allstar on our repos, but will give us the flexibility to ignore files that we are sure are safe
