### PR TITLE
Require codeowners

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ for code to reach `main`.
 | Require approval | yes |
 | Require signed commits | yes |
 | Require up-to-date branch before merge | yes |
+| Require review from CODEOWNERS | yes |
 
 **Compliance**:
 
@@ -73,6 +74,14 @@ for code to reach `main`.
 
 * Follow GitHub's [Branch Protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) guidance
 * If the org-wide settings aren't appropriate for your repository, override the settings in `(repository)/.allstar/branch_protection.yaml`
+
+### [CODEOWNERS](codeowners.yaml)
+
+Detects whether a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file is provided for a repository.
+
+**Remediation Hints**:
+
+* Add a [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location) to the repository
 
 ### [Dangerous Action Workflows](dangerous_workflows.yaml)
 

--- a/branch_protection.yaml
+++ b/branch_protection.yaml
@@ -18,3 +18,4 @@ optOutArchivedRepos: true
 requireApproval: true
 requireSignedCommits: true # SI-7
 requireUpToDateBranch: true
+requireCodeOwnerReviews: true

--- a/codeowners.yml
+++ b/codeowners.yml
@@ -1,0 +1,9 @@
+# Scorecard Check - Detect in-repo binaries
+# Partial implementation of
+# SI-3: Malicious Code Protection
+optConfig:
+  disableRepoOverride: false
+  optOutStrategy: true
+  optOutArchivedRepos: true
+action: issue
+requireCODEOWNERS: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add CODEOWNERS policy to check for CODEOWNERS file on all non-archived repos
- Update branch protection policy to require review from codeowners on all repos

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Requiring review from code owners is good for security because it ensures that people with the responsibility of owning code review changes and are more likely to spot any malicious changes.
